### PR TITLE
Update search results on dismiss

### DIFF
--- a/gitimoji/Views/ContentView.swift
+++ b/gitimoji/Views/ContentView.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
                                     } else {
                                         Button(action: {
                                             self.searchText = ""
+                                            self.vm.updateSearchText(width: "")
                                         }, label: {
                                             Image("DismissIcon")
                                                 .resizable()


### PR DESCRIPTION
Hi @lovetodream ! Thanks for the great app ^^
I’ve noticed that when clicking the dismiss button the search text resets, but the search results remains the same.

<img src="https://user-images.githubusercontent.com/13344923/117081478-a0165200-ad48-11eb-8715-d946b1d0fc9f.gif" width="300">

I’m learning swift at the moment so I thought I’ll try to fix it by myself 🙂

I’ve added a call to `vm.updateSearchText` from the dismiss button `action` closure.  That fixes the issue, but I feel like it’s not the right way to do it. 

Correct me if I’m wrong, but it seems that if we'll update the `searchTextBinding` value, and thus it's setter function will trigger - the `searchText` value will be updated and the `vm.updateSearchText` function will be called. This will avoid the code being replicated from the button’s action closure.
 
But I'm not sure how it's possible to do that with a `Binding` property. Do you mind guiding me through this? 