### PR TITLE
🐛 fix gitmoji list retrieval

### DIFF
--- a/gitimoji/Services/Networking.swift
+++ b/gitimoji/Services/Networking.swift
@@ -29,7 +29,7 @@ enum NetworkingError: Error {
 
 struct Networking {
     static func fetchEmojis() async throws -> [GitmojiResponse] {
-        let url = URL(string: "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json")
+        let url = URL(string: "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/gitmojis/src/gitmojis.json")
 
         guard let url = url else {
             preconditionFailure("Gitmoji fetch URL invalid")


### PR DESCRIPTION
The Gitmoji project recently switched to a monorepo structure, changing the path to the JSON file