### PR TITLE
✨ Added option to close popover automatically after copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gitimoji.xcodeproj/xcuserdata/
 timeline.xctimeline
 playground.xcworkspace
 .build/
+gitimoji.xcodeproj/project.xcworkspace/xcuserdata

--- a/gitimoji/Constants.swift
+++ b/gitimoji/Constants.swift
@@ -18,6 +18,7 @@ enum Constants {
     enum DefaultKey: String {
         case gitmojiFetchURL
         case copyEmoji
+        case closePopoverAfterCopy
     }
 
     enum Link {

--- a/gitimoji/Views/Components/EmojiRow.swift
+++ b/gitimoji/Views/Components/EmojiRow.swift
@@ -16,6 +16,9 @@ struct EmojiRow: View {
     @AppStorage(Constants.DefaultKey.copyEmoji.rawValue)
     private var copyEmoji = false
     
+    @AppStorage(Constants.DefaultKey.closePopoverAfterCopy.rawValue)
+    private var closePopoverAfterCopy = false
+    
     var body: some View {
         Button(action: {
             // copy to clipboard
@@ -55,6 +58,9 @@ struct EmojiRow: View {
         Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { timer in
             withAnimation {
                 self.recentlyCopied = false
+                if closePopoverAfterCopy {
+                    NSApp.sendAction(#selector(AppDelegate.togglePopover), to: nil, from: nil)
+                }
             }
         }
     }

--- a/gitimoji/Views/Settings/GeneralSettingsView.swift
+++ b/gitimoji/Views/Settings/GeneralSettingsView.swift
@@ -17,6 +17,9 @@ struct GeneralSettingsView: View {
     @AppStorage(Constants.DefaultKey.copyEmoji.rawValue)
     private var copyEmoji = false
 
+    @AppStorage(Constants.DefaultKey.closePopoverAfterCopy.rawValue)
+    private var closePopoverAfterCopy = false
+    
     @AppStorage(Constants.DefaultKey.gitmojiFetchURL.rawValue)
     private var url: URL = URL(string: "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/gitmojis/src/gitmojis.json")!
 
@@ -31,6 +34,13 @@ struct GeneralSettingsView: View {
                 Text("Emoji eg. 🎉").tag(true)
             }
 
+            HStack {
+                Spacer()
+                Toggle(isOn: $closePopoverAfterCopy) {
+                    Text("Close popover automatically after copy")
+                }
+            }
+            
             HStack {
                 Text("Toggle App Window")
                 Spacer()


### PR DESCRIPTION
I added an option to automatically close the popover when the Emoji has been copied. The delay of 1s (tied to the disappearance of the "Copied" feedback) seems a bit much for now, but that should be good enough for the near future imho.